### PR TITLE
fix: ship payload-manifest-check.yml on main (Roadmap #23 follow-up)

### DIFF
--- a/.github/workflows/payload-manifest-check.yml
+++ b/.github/workflows/payload-manifest-check.yml
@@ -1,0 +1,116 @@
+name: Payload Manifest Check
+
+# Gates PRs to main: every changed file must be permitted by the payload
+# manifest. The manifest lives on develop (single source of truth), and is
+# fetched at runtime so main itself stays free of template-internal config.
+#
+# This workflow ships on BOTH main and develop. It MUST live on main
+# because GitHub Actions resolves `pull_request` workflow files from the
+# PR head ref — and main-derived feature branches have only main's tree.
+# Forks (which inherit this file via main) skip the check automatically
+# when no `develop` branch exists, so the check is harmless for them.
+#
+# Per ADR-026 amendment 2026-05-21 (further revised on workflow-trigger
+# discovery), this is the single permitted workflow on main; all other
+# CI is fork-opt-in via `.github/workflows/.gitkeep`.
+#
+# References:
+# - pull_request event (workflow-file resolution rules):
+#   https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  payload-manifest-check:
+    name: payload-manifest-check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Try to checkout develop branch (manifest source)
+        id: checkout-develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          path: manifest-source
+          fetch-depth: 1
+        continue-on-error: true
+
+      - name: Checkout PR head (diff target)
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+          path: pr-head
+
+      - name: Decide whether to run the check
+        id: gate
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -f manifest-source/.claude/payload-manifest.txt ]]; then
+            entries=$(grep -cv '^[[:space:]]*\(#\|$\)' manifest-source/.claude/payload-manifest.txt)
+            echo "active=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::Payload manifest fetched from develop (${entries} entries). Gating PR."
+          else
+            echo "active=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::No payload manifest on develop (or develop branch absent). Skipping check — repo is not using the payload-manifest gating pattern."
+          fi
+
+      - name: Validate changed files against payload manifest
+        if: steps.gate.outputs.active == 'true'
+        working-directory: pr-head
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          MANIFEST="../manifest-source/.claude/payload-manifest.txt"
+
+          # Build an ERE pattern from manifest entries.
+          # Order matters:
+          #   1. escape literal dots
+          #   2. mark ** with a placeholder so the next sed does not touch it
+          #   3. convert single * to [^/]* (single-segment glob)
+          #   4. restore placeholder as .* (recursive glob, includes /)
+          PATTERN=$(grep -v '^[[:space:]]*#' "$MANIFEST" \
+            | grep -v '^[[:space:]]*$' \
+            | sed -E 's/[[:space:]]+$//' \
+            | sed -E 's/\./\\./g' \
+            | sed -E 's|\*\*|__GG_RECURSIVE__|g' \
+            | sed -E 's/\*/[^\/]*/g' \
+            | sed -E 's|__GG_RECURSIVE__|.*|g' \
+            | paste -sd '|' -)
+
+          if [[ -z "$PATTERN" ]]; then
+            echo "::error::Manifest produced no patterns (file empty or all comments)."
+            exit 1
+          fi
+
+          CHANGED=$(git diff --name-only \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}")
+
+          OFFENDERS=()
+          while IFS= read -r path; do
+            [[ -z "$path" ]] && continue
+            if ! echo "$path" | grep -qE "^($PATTERN)$"; then
+              OFFENDERS+=("$path")
+            fi
+          done <<< "$CHANGED"
+
+          if [[ ${#OFFENDERS[@]} -gt 0 ]]; then
+            echo "::error::The following paths are not allowed by the payload manifest:"
+            for p in "${OFFENDERS[@]}"; do
+              echo "  - $p"
+            done
+            echo ""
+            echo "Resolution: either (a) keep these paths off main and land them on develop only, or (b) extend .claude/payload-manifest.txt on develop to allow them, then re-run this PR."
+            exit 1
+          fi
+
+          echo "PASS: all changed paths are on the payload manifest."
+          printf '  - %s\n' "$CHANGED" | sed '/^  - $/d'


### PR DESCRIPTION
## Summary

This is the single template-internal workflow shipped to main. Discovered during AC-6/AC-12 verification of Roadmap #23: GitHub Actions resolves \`pull_request\` workflow files from the PR head ref, so a check that lives only on \`develop\` never triggers on PRs from main-derived feature branches.

The workflow:
- runs on every \`pull_request\` to main (head ref always has this file)
- tries to checkout the \`develop\` branch to fetch the manifest from its canonical location (\`.claude/payload-manifest.txt\` on develop)
- gracefully skips with a Notice on forks that have no \`develop\` branch (so this file is harmless to fork CI)
- validates each changed path against the manifest's glob patterns, failing the check (and the PR's required status) on any mismatch

This file is already added to \`.claude/payload-manifest.txt\` on develop (PR-prerequisite work in commit b53a66a) so this PR's content is on the manifest.

## Test plan

- [ ] This PR's payload-manifest-check should PASS (only changed path is \`.github/workflows/payload-manifest-check.yml\` which is now on the manifest)
- [ ] After merge, subsequent test PRs (e.g., README change) should also PASS
- [ ] A negative-case test PR with a disallowed path (e.g., \`specs/test.md\`) should FAIL the check