### PR TITLE
test: negative-case verification (expect payload-manifest-check FAIL)

### DIFF
--- a/specs/test-manifest-negative.md
+++ b/specs/test-manifest-negative.md
@@ -1,0 +1,1 @@
+# Test — this file is NOT on the payload manifest


### PR DESCRIPTION
Adds `specs/test-manifest-negative.md` (not on the manifest) to verify that payload-manifest-check correctly FAILS the PR. Close after verification.