### PR TITLE
docs: clarify CI section — main ships one template-internal workflow

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -112,9 +112,10 @@ orchestrator が product-manager (受け入れ基準) / architect (モジュー�
 
 ## CI
 
-本テンプレートは **`main` 上に GitHub Actions ワークフローを含めません**
-(設計上の意図的判断)。`.github/workflows/` フォルダは `.gitkeep` のみで
-保持されており、ここに CI を追加できることを忘れないための仕組みです。
+本テンプレートは **`main` 上に fork 向け GitHub Actions ワークフローを
+含めません** (設計上の意図的判断)。`.github/workflows/` フォルダは
+`.gitkeep` で保持されており、ここに CI を追加できることを忘れないため
+の仕組みです。
 
 GitHub ワークフローは fork ごとの選択です — プロジェクトによって必要な
 CI 構成は異なります (lint、test、coverage gate、security scan、依存更新
@@ -130,6 +131,17 @@ git checkout template/develop -- .github/workflows/<workflow>.yml
 プロジェクトに合うワークフロー (例: `ci-base.yml`、`security.yml`、
 `coverage-gate.yml`、`workaround-check.yml`) を選ぶか、独自に作成してくだ
 さい。
+
+### `main` に同梱される唯一のワークフロー
+
+`.github/workflows/payload-manifest-check.yml` は、上流テンプレートが
+自身の `main` 宛 PR を `.claude/payload-manifest.txt` (develop 上に存在)
+に対して gate するためのテンプレート内部 boundary-enforcement
+ワークフローです。fork ではこの workflow は無害に動作します — `develop`
+ブランチの checkout を試み、存在しない場合は静かに SUCCESS で skip
+します。完全に空の `.github/workflows/` を望む fork はこの 1 ファイル
+を `git rm` で削除して問題ありません。残したままにすれば、PR ごとに
+no-op success が報告されるだけです。
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ quality agents for review — you steer the hand-offs.
 
 ## CI
 
-This template ships with **no GitHub Actions workflows on `main`** by
-design. The `.github/workflows/` folder is preserved with a single
-`.gitkeep` file so you remember the slot exists.
+This template ships with **no fork-facing GitHub Actions workflows on
+`main`** by design. The `.github/workflows/` folder is preserved with
+a `.gitkeep` file so you remember the slot exists.
 
 GitHub workflows are a per-fork choice — different projects want
 different CI scaffolding (lint, test, coverage gates, security
@@ -137,6 +137,17 @@ git checkout template/develop -- .github/workflows/<workflow>.yml
 Pick the workflows that fit your project (e.g. `ci-base.yml`,
 `security.yml`, `coverage-gate.yml`, `workaround-check.yml`) — or
 write your own.
+
+### The one workflow that does ship on `main`
+
+`.github/workflows/payload-manifest-check.yml` is a template-internal
+boundary-enforcement workflow used by the upstream template to gate
+PRs to its own `main` against `.claude/payload-manifest.txt` (which
+lives on `develop`). On forks, the workflow runs harmlessly — it
+tries to checkout a `develop` branch and silently skips with success
+when none exists. Forks that want a truly empty `.github/workflows/`
+can `git rm` this single file with no consequence; forks keeping it
+see a no-op success on every PR.
 
 ---
 


### PR DESCRIPTION
Follow-up to Roadmap #23 architecture fix (PR #11). README previously claimed 'no GitHub Actions workflows on main' but the post-ship fix shipped `payload-manifest-check.yml` to main as the single template-internal boundary-enforcement workflow. This PR updates README.md + README.ja.md to reflect that, with a new subsection explaining the workflow's fork-friendly graceful-skip behavior.

## Test plan
- [ ] payload-manifest-check passes (README.md and README.ja.md are both on the manifest)