### PR TITLE
test(verify-guard): temporary PR to confirm if-guard skip evaluation (DO NOT MERGE)

### DIFF
--- a/.github/workflows/payload-manifest-check.yml
+++ b/.github/workflows/payload-manifest-check.yml
@@ -127,3 +127,16 @@ jobs:
 
           echo "PASS: all changed paths are on the payload manifest."
           printf '  - %s\n' "$CHANGED" | sed '/^  - $/d'
+
+  # TEMPORARY VERIFICATION JOB (PR will be closed without merge).
+  # Confirms the `if: github.repository == '...'` guard pattern correctly
+  # evaluates to `skipped` when the repository does NOT match. The
+  # condition below is a deliberately impossible match — this job MUST
+  # appear as `skipped` in the PR's checks tab. If it appears as
+  # `success`/`failure` instead, the guard pattern is broken.
+  verify-guard-skip-evaluation:
+    name: verify-guard-skip-evaluation (must be skipped)
+    runs-on: ubuntu-latest
+    if: github.repository == 'this-org-does-not-exist/never-matches'
+    steps:
+      - run: echo "If you see this output the guard is BROKEN."


### PR DESCRIPTION
## Purpose

Verify the third-amendment guard from PR #14 evaluates to \`skipped\` when the repository does NOT match.

## What this PR does

Adds a temporary job \`verify-guard-skip-evaluation\` to \`.github/workflows/payload-manifest-check.yml\` with:

\`\`\`yaml
if: github.repository == 'this-org-does-not-exist/never-matches'
\`\`\`

Since no repository can match that condition, the job MUST appear as **skipped** in this PR's checks tab. The verification is the CI result itself, not the code.

## Expected result

| Job | Expected |
|---|---|
| payload-manifest-check | SUCCESS (guard matches upstream → executes; payload diff is allowed) |
| verify-guard-skip-evaluation (must be skipped) | **skipped** |
| GitGuardian | SUCCESS |

## Disposition

**DO NOT MERGE.** Once the skipped status is observed, close this PR without merging and delete the branch.

If \`verify-guard-skip-evaluation\` appears as \`success\` or \`failure\` instead of \`skipped\`, the guard logic is broken — investigate before closing.