### PR TITLE
chore(manifest): transitionally re-add .devcontainer/** (ADR-027 sequencing)

### DIFF
--- a/.claude/payload-manifest.txt
+++ b/.claude/payload-manifest.txt
@@ -39,6 +39,15 @@
 .github/dependabot.yml
 
 # ---------------------------------------------------------------
+# .devcontainer/ — TRANSITIONAL (removed per ADR-028). Entry kept
+# so the main-side deletion PR passes the manifest gate (the gate
+# treats deletions as off-manifest if the deleted path is not on
+# the allowlist — see ADR-027 sequencing note). Removed in a
+# follow-up develop-only PR after the main deletion lands.
+# ---------------------------------------------------------------
+.devcontainer/**
+
+# ---------------------------------------------------------------
 # Root-level — README, CHANGELOG, LICENSE, git/env examples
 # ---------------------------------------------------------------
 README.md


### PR DESCRIPTION
## Summary

Re-adds `.devcontainer/**` to `.claude/payload-manifest.txt` with a TRANSITIONAL marker comment, so the main-side deletion PR (#19) can pass the `payload-manifest-check` gate.

## Why

PR #18 (ADR-028) removed both `.devcontainer/` and its manifest entry in the same commit. That works on develop (which has no main-targeting gates), but PR #19 (the main-side companion) failed: the gate treats every path in the diff — **including deletions** — as needing manifest membership. With `.devcontainer/**` absent from the manifest, the deleted file `.devcontainer/devcontainer.json` was reported as "not allowed."

This is exactly the sequencing issue ADR-027 documented for the `.gitignore.example` removal:

> "the manifest entry must remain in place *during* the payload PR that deletes the file, otherwise the manifest gate (which validates `git diff --name-only` against the manifest pattern set) rejects the deletion as an off-manifest path. The manifest entry is removed in a separate develop-only commit *after* the payload PR has merged"

## After this merges

1. Re-run CI on PR #19 — the gate fetches the updated develop manifest and now allows the deletion → PASS.
2. Merge PR #19.
3. Open a final develop-only PR that removes the `.devcontainer/**` entry from the manifest (clean end state).

## Files changed

- `.claude/payload-manifest.txt` (+9 lines: TRANSITIONAL section header + `.devcontainer/**` glob)