### PR TITLE
chore(manifest): remove transitional .devcontainer/** entry (ADR-028 final cleanup)

### DIFF
--- a/.claude/payload-manifest.txt
+++ b/.claude/payload-manifest.txt
@@ -39,15 +39,6 @@
 .github/dependabot.yml
 
 # ---------------------------------------------------------------
-# .devcontainer/ — TRANSITIONAL (removed per ADR-028). Entry kept
-# so the main-side deletion PR passes the manifest gate (the gate
-# treats deletions as off-manifest if the deleted path is not on
-# the allowlist — see ADR-027 sequencing note). Removed in a
-# follow-up develop-only PR after the main deletion lands.
-# ---------------------------------------------------------------
-.devcontainer/**
-
-# ---------------------------------------------------------------
 # Root-level — README, CHANGELOG, LICENSE, git/env examples
 # ---------------------------------------------------------------
 README.md


### PR DESCRIPTION
## Summary

Removes the TRANSITIONAL `.devcontainer/**` entry that PR #20 added to `.claude/payload-manifest.txt`. The entry was only needed for PR #19's lifetime (so the main-side deletion of `.devcontainer/devcontainer.json` would pass the manifest gate). PR #19 is now merged (sha 50a8a92).

## End state

- main: no `.devcontainer/` (deleted by PR #19)
- develop: no `.devcontainer/` (deleted by PR #18)
- manifest: no `.devcontainer/**` entry (this PR)

All three sides consistent.

## Sequencing recap (3-PR pattern from ADR-027, re-applied for ADR-028)

| PR | Branch | What |
|---|---|---|
| #18 | develop | Delete .devcontainer/ from develop + manifest entry + ADR-028 + CHANGELOGs + README updates |
| #20 | develop | Re-add .devcontainer/** transitionally to manifest |
| #19 | main | Delete .devcontainer/ from main + fix dead hook ref in settings.json |
| #21 (this) | develop | Remove transitional manifest entry |

Lesson: bundling the manifest entry removal into the payload-cleanup develop PR breaks the main-side gate. Future cleanup of this shape should follow ADR-027's two-PR-on-develop pattern from the start (payload PR keeps the entry; cleanup PR removes it post-main-merge).